### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --no-install-recommends && \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN pip install git+https://github.com/${OPENCADC_REPO}/caom2pipe@${OPENCADC_BRANCH}#egg=caom2pipe
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG CADC_PYTHON_VERSION=3.12
-FROM opencadc/matplotlib:${CADC_PYTHON_VERSION}-slim as builder
+FROM opencadc-metadata-curation/matplotlib:${CADC_PYTHON_VERSION}-slim as builder
 ARG CADC_PYTHON_VERSION
 
 RUN apt-get update --no-install-recommends && \

--- a/scripts/euclid_run.sh
+++ b/scripts/euclid_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="euclid"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/euclid_run_incremental.sh
+++ b/scripts/euclid_run_incremental.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="euclid"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/euclid2caom2
+github_project = opencadc-metadata-curation/euclid2caom2
 install_requires =
     cadcdata
     cadctap


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
scripts/euclid_run.sh
scripts/euclid_run_incremental.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
